### PR TITLE
Add Guardian grid and fonts

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,6 +1,8 @@
 import createCache from "@emotion/cache";
 import { CacheProvider } from "@emotion/react";
 import type { AppProps } from "next/app";
+import "../shared/styles.css";
+import "../shared/fonts.css";
 
 const cache = createCache({ key: "next" });
 

--- a/pages/food/landing-page-1.tsx
+++ b/pages/food/landing-page-1.tsx
@@ -1,35 +1,126 @@
 import { css } from "@emotion/react";
-import { Button, Footer } from "@guardian/source-react-components";
+import {
+  Button,
+  Footer,
+  SvgGuardianLogo,
+} from "@guardian/source-react-components";
+import { fonts, from, palette } from "@guardian/source-foundations";
 import { Image } from "../../shared/Image";
+import Head from "next/head";
+
+const grid = css`
+  display: grid;
+
+  grid-template-columns:
+    0px
+    [content-start]
+    repeat(4, minmax(0, 1fr))
+    [content-end]
+    0px;
+
+  column-gap: 10px;
+
+  ${from.mobileLandscape} {
+    column-gap: 20px;
+  }
+
+  ${from.tablet} {
+    grid-template-columns:
+      minmax(0, 1fr)
+      [content-start]
+      repeat(12, 40px)
+      [content-end]
+      minmax(0, 1fr);
+  }
+
+  ${from.desktop} {
+    grid-template-columns:
+      minmax(0, 1fr)
+      [content-start]
+      repeat(12, 60px)
+      [content-end]
+      minmax(0, 1fr);
+  }
+  ${from.leftCol} {
+    grid-template-columns:
+      minmax(0, 1fr)
+      [content-start]
+      repeat(14, 60px)
+      [content-end]
+      minmax(0, 1fr);
+  }
+
+  ${from.wide} {
+    grid-template-columns:
+      minmax(0, 1fr)
+      [content-start]
+      repeat(16, 60px)
+      [content-end]
+      minmax(0, 1fr);
+  }
+`;
 
 const Home = () => (
   <>
-    <main
-      css={css`
-        display: flex;
-        flex-direction: column;
-      `}
-    >
-      <h1>Let’s get cooking</h1>
+    <Head>
+      <title>Basecamp | Guardian</title>
+    </Head>
 
-      <p>Some text about this page</p>
+    <header style={{ backgroundColor: palette.brand[400] }} css={grid}>
+      <div
+        css={css`
+          width: 225px;
+          grid-column: -4 / span 2;
+          justify-self: end;
 
-      <Button>Click me</Button>
+          ${from.desktop} {
+            width: 300px;
+            grid-column: -6 / span 3;
+          }
+        `}
+      >
+        <SvgGuardianLogo textColor={palette.neutral[100]} />
+      </div>
+    </header>
 
-      <Image
-        src={
-          "https://media.guim.co.uk/1a863deb14a607837e27466c05939aa98c410bb5/0_651_3717_3717/3717.jpg"
-        }
-        alt="Ottolenghi’s salad"
-        width={300}
-        height={300}
-      />
+    <main style={{ backgroundColor: palette.neutral[100] }} css={grid}>
+      <section
+        css={css`
+          grid-area: content;
+          font-family: ${fonts.body};
+          min-height: 70dvh;
+        `}
+      >
+        <h1
+          css={css`
+            font-family: ${fonts.headline};
+            font-weight: 500;
+          `}
+        >
+          Let’s get cooking!
+        </h1>
 
-      <ol>
-        <li>First thing</li>
-        <li>Second thing</li>
-        <li>Third thing</li>
-      </ol>
+        <p>Some text about this page…</p>
+
+        <Button>Click me</Button>
+
+        <br />
+
+        <Image
+          src={
+            "https://media.guim.co.uk/1a863deb14a607837e27466c05939aa98c410bb5/0_651_3717_3717/3717.jpg"
+          }
+          alt="Ottolenghi’s salad"
+          width={300}
+          height={300}
+        />
+
+        <ol>
+          <li>First thing</li>
+          <li>Second thing</li>
+          <li>Third thing</li>
+        </ol>
+      </section>
     </main>
     <Footer />
   </>

--- a/shared/Fonts.tsx
+++ b/shared/Fonts.tsx
@@ -1,0 +1,7 @@
+export const Fonts = () => (
+  /* this is slow - do not use it for production Guardian sites */
+  <link
+    href="https://assets.guim.co.uk/static/frontend/fonts/font-faces.css"
+    rel="stylesheet"
+  />
+);

--- a/shared/fonts.css
+++ b/shared/fonts.css
@@ -1,0 +1,138 @@
+/************* Guardian Headline *************/
+
+@font-face {
+    font-family: 'GH Guardian Headline';
+    src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Light.woff2') format('woff2'),
+        url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/latin1-not-hinted/GHGuardianHeadline-Light.woff') format('woff');
+    font-weight: 300;
+    font-style: normal;
+    font-display: swap;
+}
+
+@font-face {
+    font-family: 'GH Guardian Headline';
+    src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-LightItalic.woff2') format('woff2'),
+        url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/latin1-not-hinted/GHGuardianHeadline-LightItalic.woff') format('woff');
+    font-weight: 300;
+    font-style: italic;
+    font-display: swap;
+}
+
+@font-face {
+    font-family: 'GH Guardian Headline';
+    src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Medium.woff2') format('woff2'),
+        url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/latin1-not-hinted/GHGuardianHeadline-Medium.woff') format('woff');
+    font-weight: 500;
+    font-style: normal;
+    font-display: swap;
+}
+
+@font-face {
+    font-family: 'GH Guardian Headline';
+    src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-MediumItalic.woff2') format('woff2'),
+        url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/latin1-not-hinted/GHGuardianHeadline-MediumItalic.woff') format('woff');
+    font-weight: 500;
+    font-style: italic;
+    font-display: swap;
+}
+
+@font-face {
+    font-family: 'GH Guardian Headline';
+    src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Bold.woff2') format('woff2'),
+        url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/latin1-not-hinted/GHGuardianHeadline-Bold.woff') format('woff');
+    font-weight: 700;
+    font-style: normal;
+    font-display: swap;
+}
+
+/************* Guardian Text Egyptian *************/
+
+@font-face {
+    font-family: 'GuardianTextEgyptian';
+    src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-Regular.woff2') format('woff2'),
+        url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/latin1-not-hinted/GuardianTextEgyptian-Regular.woff') format('woff');
+    font-weight: 400;
+    font-style: normal;
+    font-display: swap;
+}
+
+@font-face {
+    font-family: 'GuardianTextEgyptian';
+    src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-RegularItalic.woff2') format('woff2'),
+        url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/latin1-not-hinted/GuardianTextEgyptian-RegularItalic.woff') format('woff');
+    font-weight: 400;
+    font-style: italic;
+    font-display: swap;
+}
+
+@font-face {
+    font-family: 'GuardianTextEgyptian';
+    src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-Bold.woff2') format('woff2'),
+        url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/latin1-not-hinted/GuardianTextEgyptian-Bold.woff') format('woff');
+    font-weight: 700;
+    font-style: normal;
+    font-display: swap;
+}
+
+@font-face {
+    font-family: 'GuardianTextEgyptian';
+    src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-BoldItalic.woff2') format('woff2'),
+        url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/latin1-not-hinted/GuardianTextEgyptian-BoldItalic.woff') format('woff');
+    font-weight: 700;
+    font-style: italic;
+    font-display: swap;
+}
+
+/************* Guardian Text Sans *************/
+
+@font-face {
+    font-family: 'GuardianTextSans';
+    src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-Regular.woff2') format('woff2'),
+        url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/latin1-not-hinted/GuardianTextSans-Regular.woff') format('woff');
+    font-weight: 400;
+    font-style: normal;
+    font-display: swap;
+}
+
+@font-face {
+    font-family: 'GuardianTextSans';
+    src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-RegularItalic.woff2') format('woff2'),
+        url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/latin1-not-hinted/GuardianTextSans-RegularItalic.woff') format('woff');
+    font-weight: 400;
+    font-style: italic;
+    font-display: swap;
+}
+
+@font-face {
+    font-family: 'GuardianTextSans';
+    src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-Bold.woff2') format('woff2'),
+        url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/latin1-not-hinted/GuardianTextSans-Bold.woff') format('woff');
+    font-weight: 700;
+    font-style: normal;
+    font-display: swap;
+}
+
+@font-face {
+    font-family: 'GuardianTextSans';
+    src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-BoldItalic.woff2') format('woff2'),
+        url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/latin1-not-hinted/GuardianTextSans-BoldItalic.woff') format('woff');
+    font-weight: 700;
+    font-style: italic;
+    font-display: swap;
+}
+
+/************* Guardian Titlepiece *************/
+
+@font-face {
+    font-family: 'GT Guardian Titlepiece';
+    /*
+	This is a design flourish and needs the full charset to work as intended.
+	This makes the file too big in ttf (80kb vs 27kb).
+	Only serve this to woff*-compatible devices.
+	*/
+    src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-titlepiece/full-not-hinted/GTGuardianTitlepiece-Bold.woff2') format('woff2'),
+        url('https://assets.guim.co.uk/static/frontend/fonts/guardian-titlepiece/full-not-hinted/GTGuardianTitlepiece-Bold.woff') format('woff');
+    font-weight: 700;
+    font-style: normal;
+    font-display: swap;
+}

--- a/shared/styles.css
+++ b/shared/styles.css
@@ -1,0 +1,9 @@
+html {
+    background-color: #052962;
+}
+
+body {
+    padding: 0;
+    margin: 0;
+
+}


### PR DESCRIPTION

## What does this change?

Add Guardian grid and fonts.

## How to test

Locally with `pnpm dev`

## How can we measure success?

Things look official

## Have we considered potential risks?

No.

## Images

<img width="768" alt="image" src="https://github.com/guardian/basecamp/assets/76776/a4976e7a-faea-4faf-873e-5540eba0a96b">

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [x] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [x] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
