### PR TITLE
Grid helpers

### DIFF
--- a/pages/food/landing-page-1.tsx
+++ b/pages/food/landing-page-1.tsx
@@ -1,74 +1,21 @@
 import { css } from "@emotion/react";
+import { Button, SvgGuardianLogo } from "@guardian/source-react-components";
 import {
-  Button,
-  Footer,
-  SvgGuardianLogo,
-} from "@guardian/source-react-components";
-import { fonts, from, palette } from "@guardian/source-foundations";
+  fontWeights,
+  fonts,
+  from,
+  palette,
+  space,
+} from "@guardian/source-foundations";
 import { Image } from "../../shared/Image";
 import Head from "next/head";
-
-const grid = css`
-  display: grid;
-
-  grid-template-columns:
-    [viewport-start]
-    0px
-    [content-start]
-    repeat(4, minmax(0, 1fr))
-    [content-end]
-    0px
-    [viewport-start];
-
-  column-gap: 10px;
-
-  ${from.mobileLandscape} {
-    column-gap: 20px;
-  }
-
-  ${from.tablet} {
-    grid-template-columns:
-      [viewport-start]
-      minmax(0, 1fr)
-      [content-start]
-      repeat(12, 40px)
-      [content-end]
-      minmax(0, 1fr)
-      [viewport-end];
-  }
-
-  ${from.desktop} {
-    grid-template-columns:
-      [viewport-start]
-      minmax(0, 1fr)
-      [content-start]
-      repeat(12, 60px)
-      [content-end]
-      minmax(0, 1fr)
-      [viewport-end];
-  }
-  ${from.leftCol} {
-    grid-template-columns:
-      [viewport-start]
-      minmax(0, 1fr)
-      [content-start]
-      repeat(14, 60px)
-      [content-end]
-      minmax(0, 1fr)
-      [viewport-end];
-  }
-
-  ${from.wide} {
-    grid-template-columns:
-      [viewport-start]
-      minmax(0, 1fr)
-      [content-start]
-      repeat(16, 60px)
-      [content-end]
-      minmax(0, 1fr)
-      [viewport-end];
-  }
-`;
+import {
+  Content,
+  Grid,
+  LeftColumn,
+  MainColumn,
+  Lines,
+} from "../../shared/Grid";
 
 const navLink = css`
   color: ${palette.neutral[100]};
@@ -124,11 +71,19 @@ const Home = () => (
       <title>Basecamp | Guardian</title>
     </Head>
 
-    <header style={{ backgroundColor: palette.brand[400] }} css={grid}>
+    <Grid
+      style={{
+        backgroundColor: palette.brand[400],
+        gridTemplateRows: "auto 38px",
+        rowGap: "12px",
+      }}
+      type="header"
+    >
       <div
         css={css`
           width: 225px;
           grid-column: -4 / span 2;
+          grid-row-start: 1;
           justify-self: end;
 
           ${from.desktop} {
@@ -141,20 +96,11 @@ const Home = () => (
       </div>
       <nav
         css={css`
-          grid-area: viewport;
-
-          border-top: 1px solid ${palette.brand[600]};
-
+          grid-column: content;
+          grid-row-start: 2;
           font-family: ${fonts.headline};
           font-weight: 900;
           display: flex;
-
-          ${from.tablet} {
-            grid-area: content;
-            border-left: 1px solid ${palette.brand[600]};
-            border-right: 1px solid ${palette.brand[600]};
-            margin: 0 -10px;
-          }
         `}
       >
         <a
@@ -198,25 +144,30 @@ const Home = () => (
           Lifestyle
         </a>
       </nav>
-    </header>
+      <Lines top={true} colour={palette.brand[600]} gridRowStart={2} />
+    </Grid>
 
-    <main style={{ backgroundColor: palette.neutral[100] }} css={grid}>
-      <section
-        css={css`
-          grid-area: content;
-          font-family: ${fonts.body};
+    <Grid type="main" style={{ backgroundColor: palette.neutral[100] }}>
+      <LeftColumn>
+        <div
+          css={css`
+            font-family: ${fonts.body};
+            padding-top: ${space[3]}px;
+          `}
+        >
+          Content for the left column
+        </div>
+      </LeftColumn>
+
+      <MainColumn
+        styles={css`
           min-height: 70dvh;
-
-          ${from.tablet} {
-            border-left: 1px solid ${palette.neutral[86]};
-            border-right: 1px solid ${palette.neutral[86]};
-            padding: 0 9px;
-            margin: 0 -10px;
-          }
         `}
       >
         <h1
           css={css`
+            margin: 0;
+            padding-top: ${space[2]}px;
             font-family: ${fonts.headline};
             font-weight: 500;
           `}
@@ -224,7 +175,13 @@ const Home = () => (
           Let’s get cooking!
         </h1>
 
-        <p>Some text about this page…</p>
+        <p
+          css={css`
+            font-family: ${fonts.body};
+          `}
+        >
+          Some text about this page…
+        </p>
 
         <Button>Click me</Button>
 
@@ -239,14 +196,46 @@ const Home = () => (
           height={300}
         />
 
-        <ol>
+        <ol
+          css={css`
+            font-family: ${fonts.body};
+          `}
+        >
           <li>First thing</li>
           <li>Second thing</li>
           <li>Third thing</li>
         </ol>
-      </section>
-    </main>
-    <Footer />
+      </MainColumn>
+      <Lines />
+    </Grid>
+    <Grid
+      type="footer"
+      style={{ color: palette.neutral[100], gridTemplateRows: "auto auto" }}
+    >
+      <Content
+        styles={css`
+          grid-row-start: 1;
+          font-family: ${fonts.body};
+        `}
+      >
+        <nav style={{ gridColumn: "content" }}>
+          (Need to add the Navigation links here)
+        </nav>
+      </Content>
+      <div
+        css={css`
+          grid-column: content;
+          font-family: ${fonts.textSans};
+          font-weight: ${fontWeights.regular};
+          font-size: 12px;
+          margin-top: ${space[2]}px;
+        `}
+      >
+        © 2023 Guardian News and Media Limited or its affiliated companies. All
+        rights reserved.
+      </div>
+      <Lines bottom={true} colour={palette.brand[600]} />
+    </Grid>
   </>
 );
 

--- a/pages/food/landing-page-1.tsx
+++ b/pages/food/landing-page-1.tsx
@@ -16,6 +16,7 @@ import {
   Lines,
 } from "../../shared/Grid";
 import { Header } from "../../shared/Header";
+import { Footer } from "../../shared/Footer";
 
 const Home = () => (
   <>
@@ -87,34 +88,7 @@ const Home = () => (
       <Lines />
     </Grid>
 
-    <Grid
-      type="footer"
-      style={{ color: palette.neutral[100], gridTemplateRows: "auto auto" }}
-    >
-      <Content
-        styles={css`
-          grid-row-start: 1;
-          font-family: ${fonts.body};
-        `}
-      >
-        <nav style={{ gridColumn: "content" }}>
-          (Need to add the Navigation links here)
-        </nav>
-      </Content>
-      <div
-        css={css`
-          grid-column: content;
-          font-family: ${fonts.textSans};
-          font-weight: ${fontWeights.regular};
-          font-size: 12px;
-          margin-top: ${space[2]}px;
-        `}
-      >
-        © 2023 Guardian News and Media Limited or its affiliated companies. All
-        rights reserved.
-      </div>
-      <Lines bottom={true} colour={palette.brand[600]} />
-    </Grid>
+    <Footer />
   </>
 );
 

--- a/pages/food/landing-page-1.tsx
+++ b/pages/food/landing-page-1.tsx
@@ -1,9 +1,8 @@
 import { css } from "@emotion/react";
-import { Button, SvgGuardianLogo } from "@guardian/source-react-components";
+import { Button } from "@guardian/source-react-components";
 import {
   fontWeights,
   fonts,
-  from,
   palette,
   space,
 } from "@guardian/source-foundations";
@@ -16,54 +15,7 @@ import {
   MainColumn,
   Lines,
 } from "../../shared/Grid";
-
-const navLink = css`
-  color: ${palette.neutral[100]};
-  text-decoration: none;
-  box-sizing: border-box;
-
-  padding: 5px;
-  position: relative;
-
-  font-size: 15.4px;
-  ${from.phablet} {
-    font-size: 18px;
-    padding-right: 20px;
-  }
-
-  ${from.tablet} {
-    font-size: 22px;
-  }
-
-  overflow: hidden;
-
-  ::before {
-    content: "";
-    position: absolute;
-    height: 4px;
-    top: 0;
-    left: 0;
-    width: 100%;
-    background-color: var(--colour, aquamarine);
-    transform: translateY(-4px);
-    transition: transform 120ms;
-  }
-
-  ::after {
-    content: "";
-    position: absolute;
-    right: 0;
-    top: 0;
-    height: 70%;
-    border-right: 1px solid ${palette.brand[600]};
-  }
-
-  :hover {
-    ::before {
-      transform: translateY(0);
-    }
-  }
-`;
+import { Header } from "../../shared/Header";
 
 const Home = () => (
   <>
@@ -71,81 +23,7 @@ const Home = () => (
       <title>Basecamp | Guardian</title>
     </Head>
 
-    <Grid
-      style={{
-        backgroundColor: palette.brand[400],
-        gridTemplateRows: "auto 38px",
-        rowGap: "12px",
-      }}
-      type="header"
-    >
-      <div
-        css={css`
-          width: 225px;
-          grid-column: -4 / span 2;
-          grid-row-start: 1;
-          justify-self: end;
-
-          ${from.desktop} {
-            width: 300px;
-            grid-column: -6 / span 3;
-          }
-        `}
-      >
-        <SvgGuardianLogo textColor={palette.neutral[100]} />
-      </div>
-      <nav
-        css={css`
-          grid-column: content;
-          grid-row-start: 2;
-          font-family: ${fonts.headline};
-          font-weight: 900;
-          display: flex;
-        `}
-      >
-        <a
-          // @ts-expect-error -- custom variables need to be declared
-          style={{ "--colour": palette.news[500], paddingLeft: 10 }}
-          css={navLink}
-          href="https://www.theguardian.com/news"
-        >
-          News
-        </a>
-        <a
-          // @ts-expect-error -- custom variables need to be declared
-          style={{ "--colour": palette.opinion[500] }}
-          css={navLink}
-          href="https://www.theguardian.com/commentisfree"
-        >
-          Opinion
-        </a>
-        <a
-          // @ts-expect-error -- custom variables need to be declared
-          style={{ "--colour": palette.sport[500] }}
-          css={navLink}
-          href="https://www.theguardian.com/sport"
-        >
-          Sport
-        </a>
-        <a
-          // @ts-expect-error -- custom variables need to be declared
-          style={{ "--colour": palette.culture[500] }}
-          css={navLink}
-          href="https://www.theguardian.com/culture"
-        >
-          Culture
-        </a>
-        <a
-          // @ts-expect-error -- custom variables need to be declared
-          style={{ "--colour": palette.lifestyle[500] }}
-          css={navLink}
-          href="https://www.theguardian.com/lifeandstyle"
-        >
-          Lifestyle
-        </a>
-      </nav>
-      <Lines top={true} colour={palette.brand[600]} gridRowStart={2} />
-    </Grid>
+    <Header />
 
     <Grid type="main" style={{ backgroundColor: palette.neutral[100] }}>
       <LeftColumn>
@@ -208,6 +86,7 @@ const Home = () => (
       </MainColumn>
       <Lines />
     </Grid>
+
     <Grid
       type="footer"
       style={{ color: palette.neutral[100], gridTemplateRows: "auto auto" }}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -35,7 +35,7 @@ const Home = ({ links }: InferGetStaticPropsType<typeof getStaticProps>) => (
 
     <ul>
       {links.map((link) => (
-        <li>
+        <li key={link}>
           <Link key={link} href={basePath + link.replace("index", "")}>
             {link.replaceAll(/-/g, " ")}
           </Link>

--- a/shared/Footer.tsx
+++ b/shared/Footer.tsx
@@ -1,0 +1,31 @@
+import {
+  fontWeights,
+  fonts,
+  palette,
+  space,
+} from "@guardian/source-foundations";
+import { Grid, Lines } from "./Grid";
+import { css } from "@emotion/react";
+import { Navigation } from "./Navigation";
+
+export const Footer = () => (
+  <Grid
+    type="footer"
+    style={{ color: palette.neutral[100], gridTemplateRows: "auto auto" }}
+  >
+    <Navigation gridRowStart={1} />
+    <div
+      css={css`
+        grid-column: content;
+        font-family: ${fonts.textSans};
+        font-weight: ${fontWeights.regular};
+        font-size: 12px;
+        margin-top: ${space[2]}px;
+      `}
+    >
+      © 2023 Guardian News and Media Limited or its affiliated companies. All
+      rights reserved.
+    </div>
+    <Lines bottom={true} colour={palette.brand[600]} />
+  </Grid>
+);

--- a/shared/Grid.tsx
+++ b/shared/Grid.tsx
@@ -1,0 +1,175 @@
+import { SerializedStyles, css, jsx } from "@emotion/react";
+import { between, from, palette, until } from "@guardian/source-foundations";
+import { CSSProperties, PropsWithChildren } from "react";
+
+const grid = css`
+  display: grid;
+  grid-auto-rows: auto;
+
+  grid-template-columns:
+    [viewport-start]
+    0
+    [content-start main-column-start]
+    repeat(4, minmax(0, 1fr))
+    [content-end main-column-end]
+    0
+    [viewport-end];
+
+  column-gap: 10px;
+
+  ${from.mobileLandscape} {
+    column-gap: 20px;
+  }
+
+  ${from.tablet} {
+    grid-template-columns:
+      [viewport-start]
+      minmax(0, 1fr)
+      [content-start main-column-start]
+      repeat(12, 40px)
+      [content-end main-column-end]
+      minmax(0, 1fr)
+      [viewport-end];
+  }
+
+  ${from.desktop} {
+    grid-template-columns:
+      [viewport-start]
+      minmax(0, 1fr)
+      [content-start main-column-start]
+      repeat(12, 60px)
+      [content-end main-column-end]
+      minmax(0, 1fr)
+      [viewport-end];
+  }
+  ${from.leftCol} {
+    grid-template-columns:
+      [viewport-start]
+      minmax(0, 1fr)
+      [content-start left-column-start]
+      repeat(2, 60px)
+      [left-column-end main-column-start]
+      repeat(12, 60px)
+      [content-end main-column-end]
+      minmax(0, 1fr)
+      [viewport-end];
+  }
+
+  ${from.wide} {
+    grid-template-columns:
+      [viewport-start]
+      minmax(0, 1fr)
+      [content-start left-column-start]
+      repeat(3, 60px)
+      [left-column-end main-column-start]
+      repeat(12, 60px)
+      [content-end main-column-end]
+      minmax(0, 1fr)
+      [viewport-end];
+  }
+`;
+
+/**
+ * Create a CSS grid container.
+ * Use jointly with Content, LeftCol & RightCol.
+ *
+ * @see https://theguardian.design/2a1e5182b/p/41be19-grids
+ */
+export const Grid = ({
+  type = "div",
+  children,
+  style,
+}: PropsWithChildren<{
+  type: keyof JSX.IntrinsicElements;
+  style?: CSSProperties;
+}>) => jsx(type, { css: grid, style }, children);
+
+/** Spans the entire width of the grid */
+export const Content = ({
+  children,
+  styles,
+}: PropsWithChildren<{ styles?: SerializedStyles }>) => (
+  <section style={{ gridColumn: "content" }} css={styles}>
+    {children}
+  </section>
+);
+
+export const MainColumn = ({
+  children,
+  styles,
+}: PropsWithChildren<{ styles?: SerializedStyles }>) => (
+  <section style={{ gridColumn: "main-column", gridRowStart: 1 }} css={styles}>
+    {children}
+  </section>
+);
+
+const hideUntilLeftCol = css`
+  display: none;
+  ${from.leftCol} {
+    display: block;
+  }
+`;
+/** Only visible from leftCol / 1140px */
+export const LeftColumn = ({ children }: PropsWithChildren) => (
+  <section
+    style={{ gridColumn: "left-column", gridRowStart: 1 }}
+    css={hideUntilLeftCol}
+  >
+    {children}
+  </section>
+);
+
+const hideUntilDesktop = css`
+  display: none;
+  ${from.leftCol} {
+    display: block;
+  }
+`;
+/** Only visible from desktop / 980px */
+export const RightColumn = ({ children }: PropsWithChildren) => (
+  <section style={{ gridColumn: "right-column" }} css={hideUntilDesktop}>
+    {children}
+  </section>
+);
+
+export const Lines = ({
+  colour = palette.neutral[86],
+  right = true,
+  left = true,
+  top = false,
+  bottom = false,
+  gridRowStart = 1,
+}: {
+  colour?: string;
+  right?: boolean;
+  left?: boolean;
+  top?: boolean;
+  bottom?: boolean;
+  gridRowStart?: number;
+}) => (
+  <div
+    style={{
+      gridColumn: "content",
+      gridRowStart,
+      gridRowEnd: -1,
+      borderColor: colour,
+      borderRightStyle: right ? "solid" : undefined,
+      borderLeftStyle: left ? "solid" : undefined,
+      borderTopStyle: top ? "solid" : undefined,
+      borderBottomStyle: bottom ? "solid" : undefined,
+    }}
+    css={css`
+      border-width: 1px;
+
+      margin: 0 -10px;
+
+      ${between.mobileLandscape.and.tablet} {
+        margin: 0 -20px;
+      }
+
+      ${until.tablet} {
+        border-left-style: none;
+      }
+    `}
+  />
+);

--- a/shared/Grid.tsx
+++ b/shared/Grid.tsx
@@ -63,7 +63,9 @@ const grid = css`
       repeat(3, 60px)
       [left-column-end main-column-start]
       repeat(12, 60px)
-      [content-end main-column-end]
+      [main-column-end]
+      repeat(1, 60px)
+      [content-end]
       minmax(0, 1fr)
       [viewport-end];
   }
@@ -163,7 +165,7 @@ export const Lines = ({
 
       margin: 0 -10px;
 
-      ${between.mobileLandscape.and.tablet} {
+      ${from.mobileLandscape} {
         margin: 0 -20px;
       }
 

--- a/shared/Header.tsx
+++ b/shared/Header.tsx
@@ -1,71 +1,30 @@
 import { css } from "@emotion/react";
-import { fonts, from, palette } from "@guardian/source-foundations";
+import { from, palette } from "@guardian/source-foundations";
 import { SvgGuardianLogo } from "@guardian/source-react-components";
 import { Grid, Lines } from "./Grid";
-
-const navLink = css`
-  color: ${palette.neutral[100]};
-  text-decoration: none;
-  box-sizing: border-box;
-
-  padding: 5px;
-  position: relative;
-
-  font-size: 15.4px;
-  ${from.phablet} {
-    font-size: 18px;
-    padding-right: 20px;
-  }
-
-  ${from.tablet} {
-    font-size: 22px;
-  }
-
-  overflow: hidden;
-
-  ::before {
-    content: "";
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    border-top-width: 4px;
-    border-top-style: solid;
-    border-top-color: inherit;
-    transform: translateY(-4px);
-    transition: transform 120ms;
-  }
-
-  ::after {
-    content: "";
-    position: absolute;
-    right: 0;
-    top: 0;
-    height: 70%;
-    border-right: 1px solid ${palette.brand[600]};
-  }
-
-  :hover {
-    ::before {
-      transform: translateY(0);
-    }
-  }
-`;
+import { Navigation } from "./Navigation";
 
 export const Header = () => (
   <Grid
     style={{
       backgroundColor: palette.brand[400],
-      gridTemplateRows: "auto 38px",
+      gridTemplateRows: "35px auto auto",
       rowGap: "12px",
     }}
     type="header"
   >
     <div
       css={css`
+        grid-row-start: 1;
+        grid-column: viewport;
+        background-color: ${palette.brand[300]};
+      `}
+    />
+    <div
+      css={css`
         width: 225px;
         grid-column: -4 / span 2;
-        grid-row-start: 1;
+        grid-row-start: 2;
         justify-self: end;
 
         ${from.desktop} {
@@ -76,51 +35,7 @@ export const Header = () => (
     >
       <SvgGuardianLogo textColor={palette.neutral[100]} />
     </div>
-    <nav
-      css={css`
-        grid-column: content;
-        grid-row-start: 2;
-        font-family: ${fonts.headline};
-        font-weight: 900;
-        display: flex;
-      `}
-    >
-      <a
-        style={{ borderColor: palette.news[500], paddingLeft: 10 }}
-        css={navLink}
-        href="https://www.theguardian.com/news"
-      >
-        News
-      </a>
-      <a
-        style={{ borderColor: palette.opinion[500] }}
-        css={navLink}
-        href="https://www.theguardian.com/commentisfree"
-      >
-        Opinion
-      </a>
-      <a
-        style={{ borderColor: palette.sport[500] }}
-        css={navLink}
-        href="https://www.theguardian.com/sport"
-      >
-        Sport
-      </a>
-      <a
-        style={{ borderColor: palette.culture[500] }}
-        css={navLink}
-        href="https://www.theguardian.com/culture"
-      >
-        Culture
-      </a>
-      <a
-        style={{ borderColor: palette.lifestyle[500] }}
-        css={navLink}
-        href="https://www.theguardian.com/lifeandstyle"
-      >
-        Lifestyle
-      </a>
-    </nav>
-    <Lines top={true} colour={palette.brand[600]} gridRowStart={2} />
+    <Navigation gridRowStart={3} />
+    <Lines top={true} colour={palette.brand[600]} gridRowStart={3} />
   </Grid>
 );

--- a/shared/Header.tsx
+++ b/shared/Header.tsx
@@ -1,0 +1,126 @@
+import { css } from "@emotion/react";
+import { fonts, from, palette } from "@guardian/source-foundations";
+import { SvgGuardianLogo } from "@guardian/source-react-components";
+import { Grid, Lines } from "./Grid";
+
+const navLink = css`
+  color: ${palette.neutral[100]};
+  text-decoration: none;
+  box-sizing: border-box;
+
+  padding: 5px;
+  position: relative;
+
+  font-size: 15.4px;
+  ${from.phablet} {
+    font-size: 18px;
+    padding-right: 20px;
+  }
+
+  ${from.tablet} {
+    font-size: 22px;
+  }
+
+  overflow: hidden;
+
+  ::before {
+    content: "";
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    border-top-width: 4px;
+    border-top-style: solid;
+    border-top-color: inherit;
+    transform: translateY(-4px);
+    transition: transform 120ms;
+  }
+
+  ::after {
+    content: "";
+    position: absolute;
+    right: 0;
+    top: 0;
+    height: 70%;
+    border-right: 1px solid ${palette.brand[600]};
+  }
+
+  :hover {
+    ::before {
+      transform: translateY(0);
+    }
+  }
+`;
+
+export const Header = () => (
+  <Grid
+    style={{
+      backgroundColor: palette.brand[400],
+      gridTemplateRows: "auto 38px",
+      rowGap: "12px",
+    }}
+    type="header"
+  >
+    <div
+      css={css`
+        width: 225px;
+        grid-column: -4 / span 2;
+        grid-row-start: 1;
+        justify-self: end;
+
+        ${from.desktop} {
+          width: 300px;
+          grid-column: -6 / span 3;
+        }
+      `}
+    >
+      <SvgGuardianLogo textColor={palette.neutral[100]} />
+    </div>
+    <nav
+      css={css`
+        grid-column: content;
+        grid-row-start: 2;
+        font-family: ${fonts.headline};
+        font-weight: 900;
+        display: flex;
+      `}
+    >
+      <a
+        style={{ borderColor: palette.news[500], paddingLeft: 10 }}
+        css={navLink}
+        href="https://www.theguardian.com/news"
+      >
+        News
+      </a>
+      <a
+        style={{ borderColor: palette.opinion[500] }}
+        css={navLink}
+        href="https://www.theguardian.com/commentisfree"
+      >
+        Opinion
+      </a>
+      <a
+        style={{ borderColor: palette.sport[500] }}
+        css={navLink}
+        href="https://www.theguardian.com/sport"
+      >
+        Sport
+      </a>
+      <a
+        style={{ borderColor: palette.culture[500] }}
+        css={navLink}
+        href="https://www.theguardian.com/culture"
+      >
+        Culture
+      </a>
+      <a
+        style={{ borderColor: palette.lifestyle[500] }}
+        css={navLink}
+        href="https://www.theguardian.com/lifeandstyle"
+      >
+        Lifestyle
+      </a>
+    </nav>
+    <Lines top={true} colour={palette.brand[600]} gridRowStart={2} />
+  </Grid>
+);

--- a/shared/Navigation.tsx
+++ b/shared/Navigation.tsx
@@ -1,0 +1,100 @@
+import { css } from "@emotion/react";
+import { fonts, from, palette } from "@guardian/source-foundations";
+
+const navLink = css`
+  color: ${palette.neutral[100]};
+  text-decoration: none;
+  box-sizing: border-box;
+
+  padding: 9px 5px 5px;
+  position: relative;
+  overflow: visible;
+
+  font-size: 15.4px;
+
+  ${from.phablet} {
+    font-size: 18px;
+  }
+
+  ${from.tablet} {
+    font-size: 22px;
+    padding-right: 20px;
+  }
+
+  ${from.desktop} {
+    grid-column-end: span 2;
+    padding-top: 5px;
+  }
+
+  ::after {
+    content: "";
+    position: absolute;
+    right: -10px;
+    top: 0;
+    height: 70%;
+    border-right: 1px solid ${palette.brand[600]};
+  }
+`;
+
+const pillarColour = css`
+  position: absolute;
+  top: 0;
+  left: -10px;
+  right: -10px;
+  height: 4px;
+  transform-origin: top;
+  transform: scaleY(0);
+  transition: transform 0.3s;
+
+  *:hover > & {
+    transform: scaleY(1);
+  }
+`;
+
+const pillars = [
+  { name: "News", colour: palette.news[500], path: "/news" },
+  { name: "Opinion", colour: palette.opinion[500], path: "/commentisfree" },
+  { name: "Sport", colour: palette.sport[500], path: "/sport" },
+  { name: "Culture", colour: palette.culture[500], path: "/culture" },
+  { name: "Lifestyle", colour: palette.lifestyle[500], path: "/lifeandstyle" },
+] as const satisfies ReadonlyArray<{
+  name: string;
+  colour: string;
+  path: `/${string}`;
+}>;
+
+type Props = {
+  gridRowStart: number;
+};
+export const Navigation = ({ gridRowStart }: Props) => (
+  <nav
+    style={{ gridRowStart }}
+    css={css`
+      grid-column: content;
+
+      font-family: ${fonts.headline};
+      font-weight: 900;
+
+      display: grid;
+      grid-template-columns: repeat(5, auto) 1fr;
+      gap: 20px;
+
+      ${from.desktop} {
+        grid-template-columns: repeat(10, 60px) 1fr;
+      }
+    `}
+  >
+    {pillars.map(({ name, path, colour }, index) => (
+      <a key={path} css={navLink} href={`https://www.theguardian.com${path}`}>
+        <div
+          style={{
+            backgroundColor: colour,
+            left: index === 0 ? "-19px" : undefined,
+          }}
+          css={pillarColour}
+        />
+        {name}
+      </a>
+    ))}
+  </nav>
+);


### PR DESCRIPTION
## What does this change?

Introduce CSS grid helpers (`Grid`, `LeftColumn`, `MainColumn`, `Content`, …)

Extract main design elements for composition:
- `Header`
- `Navigation`
- `Footer`

## Screenshot

| Narrow | Medium | Wide |
|--------|--------|--------|
| <img width="527" alt="image" src="https://github.com/guardian/basecamp/assets/76776/442e766d-ae58-424d-b6a9-705decd678f8"> | <img width="1006" alt="image" src="https://github.com/guardian/basecamp/assets/76776/d99b58e6-6938-4b20-b7ed-163fbb3cccd5"> | <img width="1408" alt="image" src="https://github.com/guardian/basecamp/assets/76776/52ab53ea-8409-40e1-b26b-648a0c130739"> |


